### PR TITLE
patch video_player

### DIFF
--- a/inc/public/default-templates/dotty/_video_player.html
+++ b/inc/public/default-templates/dotty/_video_player.html
@@ -1,3 +1,3 @@
-<video controls preload="auto" width="400" height="300">
+<video controls preload="auto" style="width:400px; height:300px;">
 	<source src="{{tpl:MediaURL}}">
 </video>


### PR DESCRIPTION
Attributs width et height utilisés sur d'autres éléments que les balises img, object, embed, canvas et svg sont interdits.