### PR TITLE
asynchronous check store update. addresses #108

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -88,25 +88,6 @@ $__dashboard_icons = new ArrayObject();
 $favs = $core->favs->getUserFavorites();
 $core->favs->appendDashboardIcons($__dashboard_icons);
 
-# Check plugins and themes update from repository
-$checkStoreUpdate = function ($mod, $url, $img, $icon) {
-    $repo = new dcStore($mod, $url);
-    $upd  = $repo->get(true);
-    if (!empty($upd)) {
-        $icon[0] .= '<br />' . sprintf(__('An update is available', '%s updates are available.', count($upd)), count($upd));
-        $icon[1] .= '#update';
-        $icon[2] = 'images/menu/' . $img . '-b-update.png';
-    }
-};
-if (isset($__dashboard_icons['plugins'])) {
-    $checkStoreUpdate($core->plugins, $core->blog->settings->system->store_plugin_url, 'plugins', $__dashboard_icons['plugins']);
-}
-if (isset($__dashboard_icons['blog_theme'])) {
-    $themes = new dcThemes($core);
-    $themes->loadModules($core->blog->themes_path, null);
-    $checkStoreUpdate($themes, $core->blog->settings->system->store_theme_url, 'blog-theme', $__dashboard_icons['blog_theme']);
-}
-
 # Latest news for dashboard
 $__dashboard_items = new ArrayObject([new ArrayObject(), new ArrayObject()]);
 

--- a/admin/js/_index.js
+++ b/admin/js/_index.js
@@ -57,6 +57,29 @@ dotclear.dbPostsCount = function () {
     }
   });
 };
+dotclear.dbStoreUpdate = function (store, icon, image) {
+  const params = {
+    f: 'checkStoreUpdate',
+    xd_check: dotclear.nonce,
+    store: store,
+  };
+  $.post('services.php', params, function (data) {
+    if ($('rsp[status=failed]', data).length > 0) {
+      // Silently fail as a forced checked may be done with module update page
+    } else {
+      if ($('rsp>update', data).attr('check') == 1) {
+        // Something has to be displayed
+        const xml = $('rsp>update', data).attr('ret');
+        // update link to details
+        icon.children('a').attr('href', icon.children('a').attr('href')+'#update');
+        // update icon, cope with dc_admin_icon_url() and iconset
+        icon.children('a').children('img').attr('src', icon.children('a').children('img').attr('src').replace(/([^\/]+)$/g, image+'-b-update.png'));
+        // add icon text says there is an update
+        icon.children().append('<br />').append(xml);
+      }
+    }
+  });
+};
 $(function () {
   function quickPost(f, status) {
     if (typeof jsToolBar === 'function' && dotclear.contentTb.getMode() == 'wysiwyg') {
@@ -162,6 +185,16 @@ $(function () {
       }
     }
   });
+
+  // check if store update available, if db has icon
+  if ($('#dashboard-main #icons p a[href="plugins.php"]').length) {
+    const plugins_db_icon = $('#dashboard-main #icons p a[href="plugins.php"]').parent();
+    dotclear.dbStoreUpdate('plugins', plugins_db_icon, 'plugins');
+  }
+  if ($('#dashboard-main #icons p a[href="blog_theme.php"]').length) {
+    const themes_db_icon = $('#dashboard-main #icons p a[href="blog_theme.php"]').parent();
+    dotclear.dbStoreUpdate('themes', themes_db_icon, 'blog-theme');
+  }
 
   // check if some news are available
   params = {


### PR DESCRIPTION
Pour accélérer l'affichage de la page d'accueil d'administration, et suite à l'ajout des dépôt tiers.
Suppression de la vérification de mise à jour au chargement de la page d'accueil admin par php, passage par l'api rest et jquery en asynchrone. Le fonctionnement reste le même. Requête uniquement si l'icone est présent sur le tableau de bord, gestion du cache par la class dcStore.
En bonus, cette fonction de vérification est ouverte à d'autres type de dépôt que plugins et thèmes.