### PR TITLE
open admin search page to other type

### DIFF
--- a/admin/preferences.php
+++ b/admin/preferences.php
@@ -240,6 +240,8 @@ if ($core->auth->isSuperAdmin()) {
     $users_order       = $core->auth->user_prefs->interface->users_order ?: 'asc';
     $nb_users_per_page = $core->auth->user_prefs->interface->nb_users_per_page;
 }
+// Search
+$nb_searchresults_per_page = $core->auth->user_prefs->interface->nb_searchresults_per_page;
 // All filters
 $auto_filter = $core->auth->user_prefs->interface->auto_filter;
 
@@ -372,6 +374,8 @@ if (isset($_POST['user_editor'])) {
             $core->auth->user_prefs->interface->put('users_order', $_POST['user_ui_users_order'], 'string');
             $core->auth->user_prefs->interface->put('nb_users_per_page', (integer) $_POST['user_ui_nb_users_per_page'], 'integer');
         }
+        // Search
+        $core->auth->user_prefs->interface->put('nb_searchresults_per_page', (integer) $_POST['user_ui_nb_searchresults_per_page'], 'integer');
         // All filters
         $core->auth->user_prefs->interface->put('auto_filter', !empty($_POST['user_ui_auto_filter']), 'boolean');
 
@@ -762,6 +766,13 @@ if ($core->auth->isSuperAdmin()) {
     __('users per page') . '</label></p>';
 }
 echo
+'</div>' .
+'<div class="two-boxes odd">' .
+'<hr />' . 
+'<h5>' . __('Search') . '</h5>' .
+'<p><span class="label ib">' . __('Show') . '</span> <label for="user_ui_nb_searchresults_per_page" class="classic">' .
+form::number('user_ui_nb_searchresults_per_page', 0, 999, $nb_searchresults_per_page) . ' ' .
+__('results per page') . '</label></p>' .
     '</div>' .
     '</div>';
 


### PR DESCRIPTION
Comme je commence à regarder pour l'extension du moteur de recherche je suis tombé sur cette page de l'admin, tellement petite, perdue et fermée que je ne l'avais même pas remarqué ;)

Donc sans rapport avec le tickets #69 cette modification permet d'ouvrir cette page à d'autres types que billets et commentaires. On ajoute par behavior une entrée dans la combo box et deux autres behavior pour récupérer les listes idoines. Les changements de page, les listes vides, les actions sur les listes, etc sont pris en compte.

Il manque juste 4 traductions dont deux pluriels. (Je n'ai pas encore installé ce qu'il faut pour le faire.)