### PR TITLE
Generic filter controls

### DIFF
--- a/admin/blogs.php
+++ b/admin/blogs.php
@@ -18,14 +18,7 @@ $status_combo = array_merge(
     dcAdminCombos::getBlogStatusesCombo()
 );
 
-$sortby_combo = [
-    __('Last update') => 'blog_upddt',
-    __('Blog name')   => 'UPPER(blog_name)',
-    __('Blog ID')     => 'B.blog_id',
-    __('Status')      => 'blog_status'
-];
-# --BEHAVIOR-- adminBlogsSortbyCombo
-$core->callBehavior('adminBlogsSortbyCombo', [& $sortby_combo]);
+$sortby_combo = dcAdminCombos::getBlogsSortsCombo();
 
 $order_combo = [
     __('Descending') => 'desc',
@@ -43,9 +36,15 @@ if ($core->auth->isSuperAdmin()) {
 }
 
 $core->auth->user_prefs->addWorkspace('interface');
+// deprecated 2.20 keep for compatibility
 $default_sortby = $core->auth->user_prefs->interface->blogs_sortby ?: 'blog_upddt';
 $default_order  = $core->auth->user_prefs->interface->blogs_order ?: 'desc';
 $nb_per_page    = $core->auth->user_prefs->interface->nb_blogs_per_page ?: 30;
+
+$sorts_user = @$core->auth->user_prefs->interface->sorts;
+$default_sortby = $sorts_user['blogs'][0] ?? $default_sortby;
+$default_order  = $sorts_user['blogs'][1] ?? $default_order;
+$nb_per_page    = $sorts_user['blogs'][2] ?? $nb_per_page;
 
 # Requests
 $q      = !empty($_GET['q']) ? $_GET['q'] : '';

--- a/admin/comments.php
+++ b/admin/comments.php
@@ -37,15 +37,7 @@ $type_combo = [
     __('Trackback') => 'tb'
 ];
 
-$sortby_combo = [
-    __('Date')        => 'comment_dt',
-    __('Entry title') => 'post_title',
-    __('Entry date')  => 'post_dt',
-    __('Author')      => 'comment_author',
-    __('Status')      => 'comment_status'
-];
-# --BEHAVIOR-- adminCommentsSortbyCombo
-$core->callBehavior('adminCommentsSortbyCombo', [& $sortby_combo]);
+$sortby_combo = dcAdminCombos::getCommentsSortsCombo();
 
 $sortby_lex = [
     // key in sorty_combo (see above) => field in SQL request
@@ -64,9 +56,15 @@ $order_combo = [
 /* Get comments
 -------------------------------------------------------- */
 $core->auth->user_prefs->addWorkspace('interface');
+// deprecated 2.20 keep for compatibility
 $default_sortby = $core->auth->user_prefs->interface->comments_sortby ?: 'comment_dt';
 $default_order  = $core->auth->user_prefs->interface->comments_order ?: 'desc';
 $nb_per_page    = $core->auth->user_prefs->interface->nb_comments_per_page ?: 30;
+
+$sorts_user = @$core->auth->user_prefs->interface->sorts;
+$default_sortby = $sorts_user['comments'][0] ?? $default_sortby;
+$default_order  = $sorts_user['comments'][1] ?? $default_order;
+$nb_per_page    = $sorts_user['comments'][2] ?? $nb_per_page;
 
 # Filters
 $author = $_GET['author'] ?? '';

--- a/admin/posts.php
+++ b/admin/posts.php
@@ -128,19 +128,7 @@ $format_combo = array_merge(
     $available_formats
 );
 
-$sortby_combo = [
-    __('Date')                 => 'post_dt',
-    __('Title')                => 'post_title',
-    __('Category')             => 'cat_title',
-    __('Author')               => 'user_id',
-    __('Status')               => 'post_status',
-    __('Selected')             => 'post_selected',
-    __('Number of comments')   => 'nb_comment',
-    __('Number of trackbacks') => 'nb_trackback'
-];
-
-# --BEHAVIOR-- adminPostsSortbyCombo
-$core->callBehavior('adminPostsSortbyCombo', [& $sortby_combo]);
+$sortby_combo = dcAdminCombos::getPostsSortsCombo();
 
 $sortby_lex = [
     // key in sorty_combo (see above) => field in SQL request
@@ -167,9 +155,15 @@ if ($posts_actions_page->process()) {
 /* Get posts
 -------------------------------------------------------- */
 $core->auth->user_prefs->addWorkspace('interface');
+// deprecated 2.20 keep for compatibility
 $default_sortby = $core->auth->user_prefs->interface->posts_sortby ?: 'post_dt';
 $default_order  = $core->auth->user_prefs->interface->posts_order ?: 'desc';
 $nb_per_page    = $core->auth->user_prefs->interface->nb_posts_per_page ?: 30;
+
+$sorts_user = @$core->auth->user_prefs->interface->sorts;
+$default_sortby = $sorts_user['posts'][0] ?? $default_sortby;
+$default_order  = $sorts_user['posts'][1] ?? $default_order;
+$nb_per_page    = $sorts_user['posts'][2] ?? $nb_per_page;
 
 # Filters
 $user_id    = !empty($_GET['user_id']) ? $_GET['user_id'] : '';

--- a/admin/preferences.php
+++ b/admin/preferences.php
@@ -153,7 +153,10 @@ $cols = [
     ]]
 ];
 $cols = new arrayObject($cols);
+
+# --BEHAVIOR-- adminColumnsLists
 $core->callBehavior('adminColumnsLists', $core, $cols);
+
 # Load user settings
 $cols_user = @$core->auth->user_prefs->interface->cols;
 if (is_array($cols_user)) {
@@ -168,14 +171,17 @@ if (is_array($cols_user)) {
 
 # Get default sortby, order, nbperpage (admin lists)
 $sorts = array_merge(
-    dcAdminCombos::getPostsSortsCombo(),
-    dcAdminCombos::getCommentsSortsCombo(),
-    dcAdminCombos::getBlogsSortsCombo(),
-    dcAdminCombos::getUsersSortsCombo(),
+    dcAdminCombos::getPostsSortsCombo(true),
+    dcAdminCombos::getCommentsSortsCombo(true),
+    dcAdminCombos::getBlogsSortsCombo(true),
+    dcAdminCombos::getUsersSortsCombo(true),
     ['search' => [__('Search'), null, null, null, [__('results per page'), 20]]]
 );
 $sorts = new arrayObject($sorts);
+
+# --BEHAVIOR-- adminSortsLists
 $core->callBehavior('adminSortsLists', $core, $sorts);
+
 # Load user settings
 //ex: $sorts_user = [blogs => [blog_id, desc, 20]]
 $sorts_user = @$core->auth->user_prefs->interface->sorts;

--- a/admin/preferences.php
+++ b/admin/preferences.php
@@ -166,82 +166,36 @@ if (is_array($cols_user)) {
     }
 }
 
-$posts_sortby_combo = [
-    __('Date')                 => 'post_dt',
-    __('Title')                => 'post_title',
-    __('Category')             => 'cat_title',
-    __('Author')               => 'user_id',
-    __('Status')               => 'post_status',
-    __('Selected')             => 'post_selected',
-    __('Number of comments')   => 'nb_comment',
-    __('Number of trackbacks') => 'nb_trackback'
-];
-# --BEHAVIOR-- adminPostsSortbyCombo
-$core->callBehavior('adminPostsSortbyCombo', [& $posts_sortby_combo]);
-
-$comments_sortby_combo = [
-    __('Date')        => 'comment_dt',
-    __('Entry title') => 'post_title',
-    __('Entry date')  => 'post_dt',
-    __('Author')      => 'comment_author',
-    __('Status')      => 'comment_status',
-    __('IP')          => 'comment_ip',
-    __('Spam filter') => 'comment_spam_filter'
-];
-# --BEHAVIOR-- adminCommentsSortbyCombo
-$core->callBehavior('adminCommentsSortbyCombo', [& $comments_sortby_combo]);
-
-$blogs_sortby_combo = [
-    __('Last update') => 'blog_upddt',
-    __('Blog name')   => 'UPPER(blog_name)',
-    __('Blog ID')     => 'B.blog_id',
-    __('Status')      => 'blog_status'
-];
-# --BEHAVIOR-- adminBlogsSortbyCombo
-$core->callBehavior('adminBlogsSortbyCombo', [& $blogs_sortby_combo]);
-
-$users_sortby_combo = [];
-if ($core->auth->isSuperAdmin()) {
-    $users_sortby_combo = [
-        __('Username')          => 'user_id',
-        __('Last Name')         => 'user_name',
-        __('First Name')        => 'user_firstname',
-        __('Display name')      => 'user_displayname',
-        __('Number of entries') => 'nb_post'
-    ];
-    # --BEHAVIOR-- adminUsersSortbyCombo
-    $core->callBehavior('adminUsersSortbyCombo', [& $users_sortby_combo]);
+# Get default sortby, order, nbperpage (admin lists)
+$sorts = array_merge(
+    dcAdminCombos::getPostsSortsCombo(),
+    dcAdminCombos::getCommentsSortsCombo(),
+    dcAdminCombos::getBlogsSortsCombo(),
+    dcAdminCombos::getUsersSortsCombo(),
+    ['search' => [__('Search'), null, null, null, [__('results per page'), 20]]]
+);
+$sorts = new arrayObject($sorts);
+$core->callBehavior('adminSortsLists', $core, $sorts);
+# Load user settings
+//ex: $sorts_user = [blogs => [blog_id, desc, 20]]
+$sorts_user = @$core->auth->user_prefs->interface->sorts;
+if (is_array($sorts_user)) {
+    foreach ($sorts_user as $st => $sf) {
+        if (null !== $sorts[$st][1] && in_array($sf[0], $sorts[$st][1])) {
+            $sorts[$st][2] = $sf[0];
+        }
+        if (null !== $sorts[$st][3] && in_array($sf[1], ['asc', 'desc'])) {
+            $sorts[$st][3] = $sf[1];
+        }
+        if (null !== $sorts[$st][4] && is_int($sf[2])) {
+            $sorts[$st][4][1] = abs($sf[2]);
+        }
+    }
 }
-
 $order_combo = [
     __('Descending') => 'desc',
     __('Ascending')  => 'asc'
 ];
-
-# Load user settings for lists options
-// Posts
-$posts_sortby      = $core->auth->user_prefs->interface->posts_sortby ?: 'post_dt';
-$posts_order       = $core->auth->user_prefs->interface->posts_order ?: 'desc';
-$nb_posts_per_page = $core->auth->user_prefs->interface->nb_posts_per_page;
-// Comments
-$comments_sortby      = $core->auth->user_prefs->interface->comments_sortby ?: 'comment_dt';
-$comments_order       = $core->auth->user_prefs->interface->comments_order ?: 'desc';
-$nb_comments_per_page = $core->auth->user_prefs->interface->nb_comments_per_page;
-// Blogs
-$blogs_sortby      = $core->auth->user_prefs->interface->blogs_sortby ?: 'blog_upddt';
-$blogs_order       = $core->auth->user_prefs->interface->blogs_order ?: 'desc';
-$nb_blogs_per_page = $core->auth->user_prefs->interface->nb_blogs_per_page;
-$users_sortby      = '';
-$users_order       = '';
-$nb_users_per_page = 0;
-if ($core->auth->isSuperAdmin()) {
-    // Users
-    $users_sortby      = $core->auth->user_prefs->interface->users_sortby ?: 'user_id';
-    $users_order       = $core->auth->user_prefs->interface->users_order ?: 'asc';
-    $nb_users_per_page = $core->auth->user_prefs->interface->nb_users_per_page;
-}
-// Search
-$nb_searchresults_per_page = $core->auth->user_prefs->interface->nb_searchresults_per_page;
 // All filters
 $auto_filter = $core->auth->user_prefs->interface->auto_filter;
 
@@ -356,26 +310,22 @@ if (isset($_POST['user_editor'])) {
         $core->auth->user_prefs->interface->put('cols', $cu, 'array');
 
         # Update user lists options
-        // Posts
-        $core->auth->user_prefs->interface->put('posts_sortby', $_POST['user_ui_posts_sortby'], 'string');
-        $core->auth->user_prefs->interface->put('posts_order', $_POST['user_ui_posts_order'], 'string');
-        $core->auth->user_prefs->interface->put('nb_posts_per_page', (integer) $_POST['user_ui_nb_posts_per_page'], 'integer');
-        // Comments
-        $core->auth->user_prefs->interface->put('comments_sortby', $_POST['user_ui_comments_sortby'], 'string');
-        $core->auth->user_prefs->interface->put('comments_order', $_POST['user_ui_comments_order'], 'string');
-        $core->auth->user_prefs->interface->put('nb_comments_per_page', (integer) $_POST['user_ui_nb_comments_per_page'], 'integer');
-        // Blogs
-        $core->auth->user_prefs->interface->put('blogs_sortby', $_POST['user_ui_blogs_sortby'], 'string');
-        $core->auth->user_prefs->interface->put('blogs_order', $_POST['user_ui_blogs_order'], 'string');
-        $core->auth->user_prefs->interface->put('nb_blogs_per_page', (integer) $_POST['user_ui_nb_blogs_per_page'], 'integer');
-        if ($core->auth->isSuperAdmin()) {
-            // Users
-            $core->auth->user_prefs->interface->put('users_sortby', $_POST['user_ui_users_sortby'], 'string');
-            $core->auth->user_prefs->interface->put('users_order', $_POST['user_ui_users_order'], 'string');
-            $core->auth->user_prefs->interface->put('nb_users_per_page', (integer) $_POST['user_ui_nb_users_per_page'], 'integer');
+        $su = [];
+        foreach ($sorts as $sort_type => $sort_data) {
+            if (null !== $sort_data[1]) {
+                $k = 'sorts_' . $sort_type . '_sortby';
+                $su[$sort_type][0] = isset($_POST[$k]) && in_array($_POST[$k], $sort_data[1]) ? $_POST[$k] : $sort_data[2];
+            }
+            if (null !== $sort_data[3]) {
+                $k = 'sorts_' . $sort_type . '_order';
+                $su[$sort_type][1] = isset($_POST[$k]) && in_array($_POST[$k], ['asc', 'desc']) ? $_POST[$k] : $sort_data[3];
+            }
+            if (null !== $sort_data[4]) {
+                $k = 'sorts_' . $sort_type . '_nb_per_page';
+                $su[$sort_type][2] = isset($_POST[$k]) ? abs((integer) $_POST[$k]) : 0;
+            }
         }
-        // Search
-        $core->auth->user_prefs->interface->put('nb_searchresults_per_page', (integer) $_POST['user_ui_nb_searchresults_per_page'], 'integer');
+        $core->auth->user_prefs->interface->put('sorts', $su, 'array');
         // All filters
         $core->auth->user_prefs->interface->put('auto_filter', !empty($_POST['user_ui_auto_filter']), 'boolean');
 
@@ -723,58 +673,35 @@ echo
 '<h4 id="user_options_lists">' . __('Options for lists') . '</h4>' .
 '<p><label for="user_ui_auto_filter" class="classic">' .
 form::checkbox('user_ui_auto_filter', 1, $auto_filter) . ' ' .
-__('Apply filters on the fly') . '</label></p>' .
-'<hr />' .
-'<div class="two-boxes odd">' .
-'<h5>' . __('Posts') . '</h5>' .
-'<p class="field"><label for="user_ui_posts_sortby">' . __('Order by:') . '</label> ' .
-form::combo('user_ui_posts_sortby', $posts_sortby_combo, $posts_sortby) . '</p>' .
-'<p class="field"><label for="user_ui_posts_order">' . __('Sort:') . '</label> ' .
-form::combo('user_ui_posts_order', $order_combo, $posts_order) . '</p>' .
-'<p><span class="label ib">' . __('Show') . '</span> <label for="user_ui_nb_posts_per_page" class="classic">' .
-form::number('user_ui_nb_posts_per_page', 0, 999, $nb_posts_per_page) . ' ' .
-__('entries per page') . '</label></p>' .
-'<hr />' .
-'<h5>' . __('Comments') . '</h5>' .
-'<p class="field"><label for="user_ui_comments_sortby">' . __('Order by:') . '</label> ' .
-form::combo('user_ui_comments_sortby', $comments_sortby_combo, $comments_sortby) . '</p>' .
-'<p class="field"><label for="user_ui_comments_order">' . __('Sort:') . '</label> ' .
-form::combo('user_ui_comments_order', $order_combo, $comments_order) . '</p>' .
-'<p><span class="label ib">' . __('Show') . '</span> <label for="user_ui_nb_comments_per_page" class="classic">' .
-form::number('user_ui_nb_comments_per_page', 0, 999, $nb_comments_per_page) . ' ' .
-__('comments per page') . '</label></p>' .
-'</div>' .
-'<div class="two-boxes even">' .
-'<h5>' . __('Blogs') . '</h5>' .
-'<p class="field"><label for="user_ui_blogs_sortby">' . __('Order by:') . '</label> ' .
-form::combo('user_ui_blogs_sortby', $blogs_sortby_combo, $blogs_sortby) . '</p>' .
-'<p class="field"><label for="user_ui_blogs_order">' . __('Sort:') . '</label> ' .
-form::combo('user_ui_blogs_order', $order_combo, $blogs_order) . '</p>' .
-'<p><span class="label ib">' . __('Show') . '</span> <label for="user_ui_nb_blogs_per_page" class="classic">' .
-form::number('user_ui_nb_blogs_per_page', 0, 999, $nb_blogs_per_page) . ' ' .
-__('blogs per page') . '</label></p>';
-if ($core->auth->isSuperAdmin()) {
-    echo
-    '<hr />' .
-    '<h5>' . __('Users') . '</h5>' .
-    '<p class="field"><label for="user_ui_users_sortby">' . __('Order by:') . '</label> ' .
-    form::combo('user_ui_users_sortby', $users_sortby_combo, $users_sortby) . '</p>' .
-    '<p class="field"><label for="user_ui_users_order">' . __('Sort:') . '</label> ' .
-    form::combo('user_ui_users_order', $order_combo, $users_order) . '</p>' .
-    '<p><span class="label ib">' . __('Show') . '</span> <label for="user_ui_nb_users_per_page" class="classic">' .
-    form::number('user_ui_nb_users_per_page', 0, 999, $nb_users_per_page) . ' ' .
-    __('users per page') . '</label></p>';
+__('Apply filters on the fly') . '</label></p>';
+
+$odd = true;
+foreach ($sorts as $sort_type => $sort_data) {
+    if ($odd) {
+        echo '<hr />';
+    }
+    echo '<div class="two-boxes ' . ($odd ? 'odd' : 'even') . '">';
+    echo '<h5>' . $sort_data[0] . '</h5>';
+    if (null !== $sort_data[1]) {
+        echo
+        '<p class="field"><label for="sorts_' . $sort_type . '_sortby">' . __('Order by:') . '</label> ' .
+        form::combo('sorts_' . $sort_type . '_sortby', $sort_data[1], $sort_data[2]) . '</p>';
+    }
+    if (null !== $sort_data[3]) {
+        echo
+        '<p class="field"><label for="sorts_' . $sort_type . '_order">' . __('Sort:') . '</label> ' .
+        form::combo('sorts_' . $sort_type . '_order', $order_combo, $sort_data[3]) . '</p>';
+    }
+    if (null != $sort_data[4]) {
+        echo
+        '<p><span class="label ib">' . __('Show') . '</span> <label for="sorts_' . $sort_type . '_nb_per_page" class="classic">' .
+        form::number('sorts_' . $sort_type . '_nb_per_page', 0, 999, $sort_data[4][1]) . ' ' .
+        $sort_data[4][0] . '</label></p>';
+    }
+    echo '</div>';
+    $odd = !$odd;
 }
-echo
-'</div>' .
-'<div class="two-boxes odd">' .
-'<hr />' . 
-'<h5>' . __('Search') . '</h5>' .
-'<p><span class="label ib">' . __('Show') . '</span> <label for="user_ui_nb_searchresults_per_page" class="classic">' .
-form::number('user_ui_nb_searchresults_per_page', 0, 999, $nb_searchresults_per_page) . ' ' .
-__('results per page') . '</label></p>' .
-    '</div>' .
-    '</div>';
+echo '</div>';
 
 echo
 '<div class="fieldset">' .

--- a/admin/services.php
+++ b/admin/services.php
@@ -651,10 +651,10 @@ class dcRestMethods
         }
 
         $sorts = array_merge(
-            dcAdminCombos::getPostsSortsCombo(),
-            dcAdminCombos::getCommentsSortsCombo(),
-            dcAdminCombos::getBlogsSortsCombo(),
-            dcAdminCombos::getUsersSortsCombo(),
+            dcAdminCombos::getPostsSortsCombo(true),
+            dcAdminCombos::getCommentsSortsCombo(true),
+            dcAdminCombos::getBlogsSortsCombo(true),
+            dcAdminCombos::getUsersSortsCombo(true),
             ['search' => [__('Search'), null, null, null, [__('results per page'), 20]]]
         );
         $sorts = new arrayObject($sorts);

--- a/admin/services.php
+++ b/admin/services.php
@@ -646,65 +646,57 @@ class dcRestMethods
         if (empty($post['id'])) {
             throw new Exception('No list name');
         }
-        if (!in_array($post['id'], ['posts', 'comments', 'blogs', 'users'])) {
+        if ($core->auth->user_prefs->interface === null) {
+            $core->auth->user_prefs->addWorkspace('interface');
+        }
+
+        $sorts = array_merge(
+            dcAdminCombos::getPostsSortsCombo(),
+            dcAdminCombos::getCommentsSortsCombo(),
+            dcAdminCombos::getBlogsSortsCombo(),
+            dcAdminCombos::getUsersSortsCombo(),
+            ['search' => [__('Search'), null, null, null, [__('results per page'), 20]]]
+        );
+        $sorts = new arrayObject($sorts);
+
+        # --BEHAVIOR-- adminSortsLists
+        $core->callBehavior('adminSortsLists', $core, $sorts);
+
+        $sorts_user = @$core->auth->user_prefs->interface->sorts;
+        if (is_array($sorts_user)) {
+            foreach ($sorts_user as $st => $sf) {
+                if (null !== $sorts[$st][1] && in_array($sf[0], $sorts[$st][1])) {
+                    $sorts[$st][2] = $sf[0];
+                }
+                if (null !== $sorts[$st][3] && in_array($sf[1], ['asc', 'desc'])) {
+                    $sorts[$st][3] = $sf[1];
+                }
+                if (null !== $sorts[$st][4] && is_int($sf[2])) {
+                    $sorts[$st][4][1] = abs($sf[2]);
+                }
+            }
+        }
+
+        if (!isset($sorts[$post['id']])) {
             throw new Exception('List name invalid');
         }
 
         $res = new xmlTag('result');
 
-        if ($core->auth->user_prefs->interface === null) {
-            $core->auth->user_prefs->addWorkspace('interface');
+        if (null !== $sorts[$post['id']][1]) {
+            $k = 'sort';
+            $sorts_user[$post['id']][0] = isset($post[$k]) && in_array($post[$k], $sorts[$post['id']][1]) ? $post[$k] : $sorts[$post['id']][2];
         }
-        switch ($post['id']) {
-            case 'posts':
-                if (isset($post['nb_per_page'])) {
-                    $core->auth->user_prefs->interface->put('nb_posts_per_page', (integer) $post['nb_per_page']);
-                }
-                if (isset($post['sort'])) {
-                    $core->auth->user_prefs->interface->put('posts_sortby', $post['sort']);
-                }
-                if (isset($post['order'])) {
-                    $core->auth->user_prefs->interface->put('posts_order', $post['order']);
-                }
-
-                break;
-            case 'comments':
-                if (isset($post['nb_per_page'])) {
-                    $core->auth->user_prefs->interface->put('nb_comments_per_page', (integer) $post['nb_per_page']);
-                }
-                if (isset($post['sort'])) {
-                    $core->auth->user_prefs->interface->put('comments_sortby', $post['sort']);
-                }
-                if (isset($post['order'])) {
-                    $core->auth->user_prefs->interface->put('comments_order', $post['order']);
-                }
-
-                break;
-            case 'blogs':
-                if (isset($post['nb_per_page'])) {
-                    $core->auth->user_prefs->interface->put('nb_blogs_per_page', (integer) $post['nb_per_page']);
-                }
-                if (isset($post['sort'])) {
-                    $core->auth->user_prefs->interface->put('blogs_sortby', $post['sort']);
-                }
-                if (isset($post['order'])) {
-                    $core->auth->user_prefs->interface->put('blogs_order', $post['order']);
-                }
-
-                break;
-            case 'users':
-                if (isset($post['nb_per_page'])) {
-                    $core->auth->user_prefs->interface->put('nb_users_per_page', (integer) $post['nb_per_page']);
-                }
-                if (isset($post['sort'])) {
-                    $core->auth->user_prefs->interface->put('users_sortby', $post['sort']);
-                }
-                if (isset($post['order'])) {
-                    $core->auth->user_prefs->interface->put('users_order', $post['order']);
-                }
-
-                break;
+        if (null !== $sorts[$post['id']][3]) {
+            $k = 'order';
+            $sorts_user[$post['id']][1] = isset($post[$k]) && in_array($post[$k], ['asc', 'desc']) ? $post[$k] : $sorts[$post['id']][3];
         }
+        if (null !== $sorts[$post['id']][4]) {
+            $k = 'nb_per_page';
+            $sorts_user[$post['id']][2] = isset($post[$k]) ? abs((integer) $post[$k]) : 0;
+        }
+        $core->auth->user_prefs->interface->put('sorts', $sorts_user, 'array');
+
         $res->msg = __('List options saved');
 
         return $res;

--- a/admin/users.php
+++ b/admin/users.php
@@ -12,17 +12,7 @@ require dirname(__FILE__) . '/../inc/admin/prepend.php';
 
 dcPage::checkSuper();
 
-# Creating filter combo boxes
-$sortby_combo = [
-    __('Username')          => 'user_id',
-    __('Last Name')         => 'user_name',
-    __('First Name')        => 'user_firstname',
-    __('Display name')      => 'user_displayname',
-    __('Number of entries') => 'nb_post'
-];
-
-# --BEHAVIOR-- adminUsersSortbyCombo
-$core->callBehavior('adminUsersSortbyCombo', [& $sortby_combo]);
+$sortby_combo = dcAdminCombos::getUsersSortsCombo();
 
 $sortby_lex = [
     // key in sorty_combo (see above) => field in SQL request
@@ -51,9 +41,15 @@ $core->callBehavior('adminUsersActionsCombo', [& $combo_action]);
 /* Get users
 -------------------------------------------------------- */
 $core->auth->user_prefs->addWorkspace('interface');
+// deprecated 2.20 keep for compatibility
 $default_sortby = $core->auth->user_prefs->interface->users_sortby ?: 'user_id';
 $default_order  = $core->auth->user_prefs->interface->users_order ?: 'asc';
 $nb_per_page    = $core->auth->user_prefs->interface->nb_users_per_page ?: 30;
+
+$sorts_user = @$core->auth->user_prefs->interface->sorts;
+$default_sortby = $sorts_user['users'][0] ?? $default_sortby;
+$default_order  = $sorts_user['users'][1] ?? $default_order;
+$nb_per_page    = $sorts_user['users'][2] ?? $nb_per_page;
 
 $q      = !empty($_GET['q']) ? $_GET['q'] : '';
 $sortby = !empty($_GET['sortby']) ? $_GET['sortby'] : $default_sortby;

--- a/inc/admin/lib.admincombos.php
+++ b/inc/admin/lib.admincombos.php
@@ -226,9 +226,9 @@ class dcAdminCombos
         return $status_combo;
     }
 
-    public static function getPostsSortsCombo()
+    public static function getPostsSortsCombo($full = false)
     {
-        $posts_sortby_combo = [
+        $sortby_combo = [
             __('Date')                 => 'post_dt',
             __('Title')                => 'post_title',
             __('Category')             => 'cat_title',
@@ -239,14 +239,16 @@ class dcAdminCombos
             __('Number of trackbacks') => 'nb_trackback'
         ];
         # --BEHAVIOR-- adminPostsSortbyCombo
-        self::$core->callBehavior('adminPostsSortbyCombo', [& $posts_sortby_combo]);
+        self::$core->callBehavior('adminPostsSortbyCombo', [& $sortby_combo]);
 
-        return ['posts' => [__('Posts'), $posts_sortby_combo, 'post_dt', 'desc', [__('entries per page'), 0]]];
+        return $full ?
+            ['posts' => [__('Posts'), $sortby_combo, 'post_dt', 'desc', [__('entries per page'), 0]]] :
+            $sortby_combo;
     }
 
-    public static function getCommentsSortsCombo()
+    public static function getCommentsSortsCombo($full = false)
     {
-        $comments_sortby_combo = [
+        $sortby_combo = [
             __('Date')        => 'comment_dt',
             __('Entry title') => 'post_title',
             __('Entry date')  => 'post_dt',
@@ -256,31 +258,36 @@ class dcAdminCombos
             __('Spam filter') => 'comment_spam_filter'
         ];
         # --BEHAVIOR-- adminCommentsSortbyCombo
-        self::$core->callBehavior('adminCommentsSortbyCombo', [& $comments_sortby_combo]);
+        self::$core->callBehavior('adminCommentsSortbyCombo', [& $sortby_combo]);
 
-        return ['comments' => [__('Comments'), $comments_sortby_combo, 'comment_dt', 'desc', [__('comments per page'), 0]]];
+        return $full ?
+            ['comments' => [__('Comments'), $sortby_combo, 'comment_dt', 'desc', [__('comments per page'), 0]]] :
+            $sortby_combo;
     }
 
-    public static function getBlogsSortsCombo()
+    public static function getBlogsSortsCombo($full = false)
     {
-        $blogs_sortby_combo = [
+        $sortby_combo = [
             __('Last update') => 'blog_upddt',
             __('Blog name')   => 'UPPER(blog_name)',
             __('Blog ID')     => 'B.blog_id',
             __('Status')      => 'blog_status'
         ];
         # --BEHAVIOR-- adminBlogsSortbyCombo
-        self::$core->callBehavior('adminBlogsSortbyCombo', [& $blogs_sortby_combo]);
+        self::$core->callBehavior('adminBlogsSortbyCombo', [& $sortby_combo]);
 
-        return ['blogs' => [__('Blogs'), $blogs_sortby_combo, 'blog_upddt', 'desc', [__('blogs per page'), 0]]];
+        return $full ?
+            ['blogs' => [__('Blogs'), $sortby_combo, 'blog_upddt', 'desc', [__('blogs per page'), 0]]] :
+            $sortby_combo;
     }
 
-    public static function getUsersSortsCombo()
+    public static function getUsersSortsCombo($full = false)
     {
         $combo = ['users' => [null, null, null, null, null]];
+        $sortby_combo = [];
 
         if (self::$core->auth->isSuperAdmin()) {
-            $users_sortby_combo = [
+            $sortby_combo = [
                 __('Username')          => 'user_id',
                 __('Last Name')         => 'user_name',
                 __('First Name')        => 'user_firstname',
@@ -288,12 +295,12 @@ class dcAdminCombos
                 __('Number of entries') => 'nb_post'
             ];
             # --BEHAVIOR-- adminUsersSortbyCombo
-            self::$core->callBehavior('adminUsersSortbyCombo', [& $users_sortby_combo]);
+            self::$core->callBehavior('adminUsersSortbyCombo', [& $sortby_combo]);
 
-            $combo = ['users' => [__('Users'), $users_sortby_combo, 'user_id', 'asc', [__('users per page'), 0]]];
+            $combo = ['users' => [__('Users'), $sortby_combo, 'user_id', 'asc', [__('users per page'), 0]]];
         }
 
-        return $combo;
+        return $full ? $combo : $sortby_combo;
     }
 }
 /*

--- a/inc/admin/lib.admincombos.php
+++ b/inc/admin/lib.admincombos.php
@@ -225,6 +225,76 @@ class dcAdminCombos
 
         return $status_combo;
     }
+
+    public static function getPostsSortsCombo()
+    {
+        $posts_sortby_combo = [
+            __('Date')                 => 'post_dt',
+            __('Title')                => 'post_title',
+            __('Category')             => 'cat_title',
+            __('Author')               => 'user_id',
+            __('Status')               => 'post_status',
+            __('Selected')             => 'post_selected',
+            __('Number of comments')   => 'nb_comment',
+            __('Number of trackbacks') => 'nb_trackback'
+        ];
+        # --BEHAVIOR-- adminPostsSortbyCombo
+        self::$core->callBehavior('adminPostsSortbyCombo', [& $posts_sortby_combo]);
+
+        return ['posts' => [__('Posts'), $posts_sortby_combo, 'post_dt', 'desc', [__('entries per page'), 0]]];
+    }
+
+    public static function getCommentsSortsCombo()
+    {
+        $comments_sortby_combo = [
+            __('Date')        => 'comment_dt',
+            __('Entry title') => 'post_title',
+            __('Entry date')  => 'post_dt',
+            __('Author')      => 'comment_author',
+            __('Status')      => 'comment_status',
+            __('IP')          => 'comment_ip',
+            __('Spam filter') => 'comment_spam_filter'
+        ];
+        # --BEHAVIOR-- adminCommentsSortbyCombo
+        self::$core->callBehavior('adminCommentsSortbyCombo', [& $comments_sortby_combo]);
+
+        return ['comments' => [__('Comments'), $comments_sortby_combo, 'comment_dt', 'desc', [__('comments per page'), 0]]];
+    }
+
+    public static function getBlogsSortsCombo()
+    {
+        $blogs_sortby_combo = [
+            __('Last update') => 'blog_upddt',
+            __('Blog name')   => 'UPPER(blog_name)',
+            __('Blog ID')     => 'B.blog_id',
+            __('Status')      => 'blog_status'
+        ];
+        # --BEHAVIOR-- adminBlogsSortbyCombo
+        self::$core->callBehavior('adminBlogsSortbyCombo', [& $blogs_sortby_combo]);
+
+        return ['blogs' => [__('Blogs'), $blogs_sortby_combo, 'blog_upddt', 'desc', [__('blogs per page'), 0]]];
+    }
+
+    public static function getUsersSortsCombo()
+    {
+        $combo = ['users' => [null, null, null, null, null]];
+
+        if (self::$core->auth->isSuperAdmin()) {
+            $users_sortby_combo = [
+                __('Username')          => 'user_id',
+                __('Last Name')         => 'user_name',
+                __('First Name')        => 'user_firstname',
+                __('Display name')      => 'user_displayname',
+                __('Number of entries') => 'nb_post'
+            ];
+            # --BEHAVIOR-- adminUsersSortbyCombo
+            self::$core->callBehavior('adminUsersSortbyCombo', [& $users_sortby_combo]);
+
+            $combo = ['users' => [__('Users'), $users_sortby_combo, 'user_id', 'asc', [__('users per page'), 0]]];
+        }
+
+        return $combo;
+    }
 }
 /*
  * Store current dcCore instance

--- a/plugins/dclegacy/_admin.php
+++ b/plugins/dclegacy/_admin.php
@@ -15,6 +15,7 @@ if (!defined('DC_CONTEXT_ADMIN')) {
 $GLOBALS['core']->addBehavior('adminPostsActionsPage', ['dcLegacyPosts', 'adminPostsActionsPage']);
 $GLOBALS['core']->addBehavior('adminPagesActionsPage', ['dcLegacyPages', 'adminPagesActionsPage']);
 $GLOBALS['core']->addBehavior('adminCommentsActionsPage', ['dcLegacyComments', 'adminCommentsActionsPage']);
+$GLOBALS['core']->addBehavior('adminSortsLists', ['dcLegacyPreferences', 'adminSortsLists']);
 
 /* Handle deprecated behaviors :
  * adminPostsActionsCombo
@@ -106,5 +107,36 @@ class dcLegacyPages
         $res = str_replace('posts_actions.php', 'plugin.php', $res);
         echo $res;
         $as->endPage();
+    }
+}
+
+/* Handle deprecated 2.20 filter-controls user preferences :
+ * Now all in $core->auth->user_prefs->interface->sorts
+ */
+class dcLegacyPreferences
+{
+    public static function adminSortsLists($core, $sorts)
+    {
+        $core->auth->user_prefs->addWorkspace('interface');
+
+        $sorts['posts'][2]        = $core->auth->user_prefs->interface->posts_sortby ?: 'post_dt';
+        $sorts['posts'][3]        = $core->auth->user_prefs->interface->posts_order ?: 'desc';
+        $sorts['posts'][4][1]     = $core->auth->user_prefs->interface->nb_posts_per_page;
+
+        $sorts['comments'][2]     = $core->auth->user_prefs->interface->comments_sortby ?: 'comment_dt';
+        $sorts['comments'][3]     = $core->auth->user_prefs->interface->comments_order ?: 'desc';
+        $sorts['comments'][4][1]  = $core->auth->user_prefs->interface->nb_comments_per_page;
+
+        $sorts['blogs'][2]        = $core->auth->user_prefs->interface->blogs_sortby ?: 'blog_upddt';
+        $sorts['blogs'][3]        = $core->auth->user_prefs->interface->blogs_order ?: 'desc';
+        $sorts['blogs'][4][1]     = $core->auth->user_prefs->interface->nb_blogs_per_page;
+
+        if ($core->auth->isSuperAdmin()) {
+            $sorts['users'][2]    = $core->auth->user_prefs->interface->users_sortby ?: 'user_id';
+            $sorts['users'][3]    = $core->auth->user_prefs->interface->users_order ?: 'asc';
+            $sorts['users'][4][1] = $core->auth->user_prefs->interface->nb_users_per_page;
+        }
+
+        $sorts['search'][4][1]    = $core->auth->user_prefs->interface->nb_searchresults_per_page;
     }
 }


### PR DESCRIPTION
Ouverture des filtre de listes par défaut (filter-controls) à d'autres types de liste.
Un seul enregistrement dans la table dc_pref regroupe désormais tous les tries des listes avec les options sortby, ordre, nbpp.
Les combo sortby existants (ainsi que leurs behaviors) sont conservés et rassemblés dans adminComboLists, ce qui est une bonne chose, ça uniformise encore un peu plus ces listes.
Pour l'utilisateur, la continuité des anciennes préférences est assuré par le plugin dcLegacy de manière assez simple.

Seul hic, sur les pages des listes par défaut (posts, comments, blogs, users) on garde un test des anciennes préférences pour assurer la continuité, mais ça reste léger et propre.