### PR TITLE
Fix % usage on admin search page breaks display

### DIFF
--- a/admin/search.php
+++ b/admin/search.php
@@ -153,7 +153,7 @@ class adminSearchPageDefault
             form::combo('action', self::$actions->getCombo()) .
             '<input id="do-action" type="submit" value="' . __('ok') . '" /></p>' .
             $core->formNonce() .
-            self::$actions->getHiddenFields() .
+            preg_replace('/%/','%%', self::$actions->getHiddenFields()) .
             '</div>' .
             '</form>'
         );
@@ -206,7 +206,7 @@ class adminSearchPageDefault
             form::combo('action', self::$actions->getCombo()) .
             '<input id="do-action" type="submit" value="' . __('ok') . '" /></p>' .
             $core->formNonce() .
-            self::$actions->getHiddenFields() .
+            preg_replace('/%/','%%', self::$actions->getHiddenFields()) .
             '</div>' .
             '</form>'
         );


### PR DESCRIPTION
Je suis tombé par hasard sur ce bug d'affichage. (croyant qu'on pouvait utiliser % sur la page admin de recherche.)