### PR TITLE
open posts list filter to others post type

### DIFF
--- a/admin/search.php
+++ b/admin/search.php
@@ -34,7 +34,7 @@ if (!empty($q) && !in_array($qtype, $qtype_combo)) {
 
 $core->auth->user_prefs->addWorkspace('interface');
 $page = !empty($_GET['page']) ? max(1, (integer) $_GET['page']) : 1;
-$nb   = $core->auth->user_prefs->interface->nb_searchresults_per_page ?: 30;
+$nb = adminUserPref::getUserFilters('search', 'nb');
 if (!empty($_GET['nb']) && (integer) $_GET['nb'] > 0) {
     $nb = (integer) $_GET['nb'];
 }

--- a/inc/admin/lib.adminfilters.php
+++ b/inc/admin/lib.adminfilters.php
@@ -387,9 +387,16 @@ class adminGenericFilter
 
 class adminPostFilter extends adminGenericFilter
 {
-    public function __construct(dcCore $core)
+    protected $post_type = 'post';
+
+    public function __construct(dcCore $core, string $type = 'posts', string $post_type = '')
     {
-        parent::__construct($core, 'posts');
+        parent::__construct($core, $type);
+
+        if (!empty($post_type) && array_key_exists($post_type, $core->getPostTypes())) {
+            $this->post_type = $post_type;
+            $this->add((new dcAdminFilter('post_type', $post_type))->param('post_type'));
+        }
 
         $filters = new arrayObject([
             dcAdminFilters::getPageFilter(),
@@ -422,7 +429,7 @@ class adminPostFilter extends adminGenericFilter
         $users = null;
 
         try {
-            $users = $this->core->blog->getPostsUsers();
+            $users = $this->core->blog->getPostsUsers($this->post_type);
             if ($users->isEmpty()) {
                 return null;
             }
@@ -453,7 +460,7 @@ class adminPostFilter extends adminGenericFilter
         $categories = null;
 
         try {
-            $categories = $this->core->blog->getCategories();
+            $categories = $this->core->blog->getCategories(['post_type' => $this->post_type]);
             if ($categories->isEmpty()) {
                 return null;
             }
@@ -584,7 +591,10 @@ class adminPostFilter extends adminGenericFilter
         $dates = null;
 
         try {
-            $dates = $this->core->blog->getDates(['type' => 'month']);
+            $dates = $this->core->blog->getDates([
+                'type'      => 'month',
+                'post_type' => $this->post_type
+            ]);
             if ($dates->isEmpty()) {
                 return null;
             }
@@ -622,7 +632,7 @@ class adminPostFilter extends adminGenericFilter
         $langs = null;
 
         try {
-            $langs = $this->core->blog->getLangs();
+            $langs = $this->core->blog->getLangs(['post_type' => $this->post_type]);
             if ($langs->isEmpty()) {
                 return null;
             }

--- a/inc/admin/lib.adminfilters.php
+++ b/inc/admin/lib.adminfilters.php
@@ -193,6 +193,21 @@ class adminGenericFilter
     }
 
     /**
+     * Remove a filter
+     *
+     * @param  string $id   The filter id
+     * @return boolean      The success
+     */
+    public function remove(string $id)
+    {
+        if (array_key_exists($id, $this->filters)) {
+            unset($this->filters[$id]);
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Get list query params
      *
      * @return array    The query params

--- a/plugins/pages/_admin.php
+++ b/plugins/pages/_admin.php
@@ -12,11 +12,12 @@ if (!defined('DC_CONTEXT_ADMIN')) {
     return;
 }
 
-$core->addBehavior('adminColumnsLists', ['pagesColumnsLists', 'adminColumnsLists']);
+$core->addBehavior('adminColumnsLists', ['pagesUserPref', 'adminColumnsLists']);
+$core->addBehavior('adminFiltersLists', ['pagesUserPref', 'adminFiltersLists']);
 $core->addBehavior('adminDashboardFavorites', ['pagesDashboard', 'pagesDashboardFavs']);
 $core->addBehavior('adminUsersActionsHeaders', 'pages_users_actions_headers');
 
-class pagesColumnsLists
+class pagesUserPref
 {
     public static function adminColumnsLists($core, $cols)
     {
@@ -27,6 +28,17 @@ class pagesColumnsLists
             'comments'   => [true, __('Comments')],
             'trackbacks' => [true, __('Trackbacks')]
         ]];
+    }
+
+    public static function adminFiltersLists($core, $sorts)
+    {
+        $sorts['pages'] = [
+            __('Pages'),
+            null,
+            null,
+            null,
+            [__('entries per page'), 30]
+        ];
     }
 }
 

--- a/plugins/pages/list.php
+++ b/plugins/pages/list.php
@@ -20,7 +20,7 @@ $params = [
 ];
 
 $page        = !empty($_GET['page']) ? max(1, (integer) $_GET['page']) : 1;
-$nb_per_page = 30;
+$nb_per_page = adminUserPref::getUserFilters('pages', 'nb');
 
 if (!empty($_GET['nb']) && (integer) $_GET['nb'] > 0) {
     $nb_per_page = (integer) $_GET['nb'];


### PR DESCRIPTION
Permet à des plugins de réutiliser le code des filtres de billets pour des billets d'un autre type que _post_.

(PS: Il faut que je regarde si le plugins pages peut en tirer avantage, car il gère sa liste par position.)