### PR TITLE
fix third party repo test on DA timeout

### DIFF
--- a/inc/core/class.dc.store.php
+++ b/inc/core/class.dc.store.php
@@ -68,11 +68,7 @@ class dcStore
             return false;
         }
 
-        if (!$parser) { // @phpstan-ignore-line
-            return false;
-        }
-
-        $raw_datas = $parser->getModules();
+        $raw_datas = !$parser ? [] : $parser->getModules();
 
         uasort($raw_datas, ['self', 'sort']);
 


### PR DESCRIPTION
Permet de laisser continuer la fonction pour tester les dépôts tiers, et la modif d'hier empêche l'erreur sur le null offset.
