### PR TITLE
add standard nethttp timeout constant

### DIFF
--- a/admin/blog_pref.php
+++ b/admin/blog_pref.php
@@ -693,7 +693,7 @@ if ($blog_id) {
 
             $client = netHttp::initClient($file, $path);
             if ($client !== false) {
-                $client->setTimeout(4);
+                $client->setTimeout(DC_QUERY_TIMEOUT);
                 $client->setUserAgent($_SERVER['HTTP_USER_AGENT']);
                 $client->get($path);
                 $status  = $client->getStatus();

--- a/inc/core/class.dc.store.reader.php
+++ b/inc/core/class.dc.store.reader.php
@@ -20,8 +20,6 @@ class dcStoreReader extends netHttp
 {
     /** @var    string    User agent used to query repository */
     protected $user_agent = 'DotClear.org RepoBrowser/0.1';
-    /** @var    integer    User agent used to query repository */
-    protected $timeout = 5;
     /** @var    array     HTTP Cache validators */
     protected $validators = null;
     /** @var    mixed     Cache temporary directory */
@@ -44,6 +42,7 @@ class dcStoreReader extends netHttp
     {
         parent::__construct('');
         $this->setUserAgent(sprintf('Dotclear/%s)', DC_VERSION));
+        $this->setTimeout(DC_QUERY_TIMEOUT);
     }
 
     /**

--- a/inc/core/class.dc.trackback.php
+++ b/inc/core/class.dc.trackback.php
@@ -802,7 +802,7 @@ class dcTrackback
     private static function initHttp($url, &$path)
     {
         $client = netHttp::initClient($url, $path);
-        $client->setTimeout(5);
+        $client->setTimeout(DC_QUERY_TIMEOUT);
         $client->setUserAgent('Dotclear - https://dotclear.org/');
         $client->useGzip(false);
         $client->setPersistReferers(false);

--- a/inc/core/class.dc.update.php
+++ b/inc/core/class.dc.update.php
@@ -108,7 +108,7 @@ class dcUpdate
             $http_get = function ($http_url) use (&$status, $path) {
                 $client = netHttp::initClient($http_url, $path);
                 if ($client !== false) {
-                    $client->setTimeout(4);
+                    $client->setTimeout(DC_QUERY_TIMEOUT);
                     $client->setUserAgent($_SERVER['HTTP_USER_AGENT']);
                     $client->get($path);
                     $status = (int) $client->getStatus();
@@ -232,7 +232,7 @@ class dcUpdate
             $http_get = function ($http_url) use (&$status, $dest, $path) {
                 $client = netHttp::initClient($http_url, $path);
                 if ($client !== false) {
-                    $client->setTimeout(4);
+                    $client->setTimeout(DC_QUERY_TIMEOUT);
                     $client->setUserAgent($_SERVER['HTTP_USER_AGENT']);
                     $client->useGzip(false);
                     $client->setPersistReferers(false);

--- a/inc/prepend.php
+++ b/inc/prepend.php
@@ -216,6 +216,10 @@ if (!defined('DC_ALLOW_REPOSITORIES')) {
     define('DC_ALLOW_REPOSITORIES', true);
 }
 
+if (!defined('DC_QUERY_TIMEOUT')) {
+    define('DC_QUERY_TIMEOUT', 4);
+}
+
 if (!defined('DC_CRYPT_ALGO')) {
     define('DC_CRYPT_ALGO', 'sha1'); // As in Dotclear 2.9 and previous
 } else {

--- a/plugins/akismet/class.dc.filter.akismet.php
+++ b/plugins/akismet/class.dc.filter.akismet.php
@@ -166,8 +166,6 @@ class akismet extends netHttp
     protected $ak_key = null;
     protected $blog_url;
 
-    protected $timeout = 3;
-
     public function __construct($blog_url, $api_key)
     {
         $this->blog_url = $blog_url;
@@ -176,7 +174,7 @@ class akismet extends netHttp
         $this->ak_path = sprintf($this->ak_path, $this->ak_version, '%s');
         $this->ak_host = $this->ak_key . '.' . $this->base_host;
 
-        parent::__construct($this->ak_host, 80);
+        parent::__construct($this->ak_host, 80, DC_QUERY_TIMEOUT);
     }
 
     public function verify()

--- a/plugins/fairTrackbacks/class.dc.filter.fairtrackbacks.php
+++ b/plugins/fairTrackbacks/class.dc.filter.fairtrackbacks.php
@@ -53,7 +53,7 @@ class dcFilterFairTrackbacks extends dcSpamFilter
             }
 
             $o = netHttp::initClient($site, $path);
-            $o->setTimeout(3);
+            $o->setTimeout(DC_QUERY_TIMEOUT);
             $o->get($path);
 
             # Trackback source does not return 200 status code


### PR DESCRIPTION
Les classes qui utilisent des requêtes netHttp ont des timeout variant entre 3, 4, 5 secondes, et codés en dur. Il serait intéressant d'avoir la main dessus par exemple à travers une constante Dotclear.