### PR TITLE
fix lost of context on media popup

### DIFF
--- a/admin/media.php
+++ b/admin/media.php
@@ -741,8 +741,11 @@ $fmt_form_media .= '</form>';
 echo '<div class="media-list">';
 echo $last_folders;
 
+// remove form filters from hidden fields
+$form_filters_hidden_fields = array_diff_key($page->values(), ['nb' => '', 'order' => '', 'sortby' => '', 'q' => '']);
+
 // display filter
-$page->display('admin.media');//, $core->adminurl->getHiddenFormFields('admin.media', array_merge($page->values(), ['q' => ''])));
+$page->display('admin.media', $core->adminurl->getHiddenFormFields('admin.media', $form_filters_hidden_fields));
 
 // display list
 $media_list->display($page, $fmt_form_media, $page->hasQuery());

--- a/inc/admin/lib.pager.php
+++ b/inc/admin/lib.pager.php
@@ -1035,7 +1035,7 @@ class adminMediaList extends adminGenericList
             echo '<p><strong>' . __('No file.') . '</strong></p>';
         }
 
-        if ($this->rs_count) {
+        if ($this->rs_count && !($filters->q && !$query)) {
             $pager = new dcPager($filters->page, $this->rs_count, $filters->nb, 10);
 
             $items = $this->rs->rows();


### PR DESCRIPTION
Il manquait les champs cachés du formulaire de filtres, et il fallait un petit tour de passe-passe pour le non affichage des résultats. Il faudrait pousser un peu les tests mais de mon coté, je n'ai pas réussi à le planter :) 