### PR TITLE
return only if set

### DIFF
--- a/inc/core/class.dc.settings.php
+++ b/inc/core/class.dc.settings.php
@@ -163,7 +163,7 @@ class dcSettings
      */
     public function get($ns)
     {
-        return $this->namespaces[$ns];
+        return ($this->namespaces[$ns] ?? null);
     }
 
     /**


### PR DESCRIPTION
To avoid having server log poluted by

```
[17-Nov-2021 13:00:55 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166
[17-Nov-2021 13:01:40 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166
[17-Nov-2021 13:01:43 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166
[17-Nov-2021 13:01:47 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166
[17-Nov-2021 13:01:48 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166
[17-Nov-2021 13:01:48 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166
[17-Nov-2021 13:01:49 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166
[17-Nov-2021 13:01:53 UTC] PHP Notice:  Undefined index: subscribetocomments_active in /home/rpms/blog/inc/core/class.dc.settings.php on line 166

```