### PR TITLE
SpamFilter, long2ip required int as parameter

### DIFF
--- a/plugins/antispam/filters/class.dc.filter.linkslookup.php
+++ b/plugins/antispam/filters/class.dc.filter.linkslookup.php
@@ -30,7 +30,7 @@ class dcFilterLinksLookup extends dcSpamFilter
 
     public function isSpam($type, $author, $email, $site, $ip, $content, $post_id, &$status)
     {
-        if (!$ip || long2ip(ip2long($ip)) != $ip) {
+        if (!$ip || long2ip((int) ip2long($ip)) != $ip) {
             return;
         }
 


### PR DESCRIPTION
and ip2long can return false