### PR TITLE
Fix unwanted Exception on destructor

### DIFF
--- a/plugins/importExport/inc/flat/class.flat.backup.php
+++ b/plugins/importExport/inc/flat/class.flat.backup.php
@@ -38,7 +38,7 @@ class flatBackup
 
     public function __destruct()
     {
-        if ($this->fp) {
+        if (is_resource($this->fp)) {
             @fclose($this->fp);
         }
     }


### PR DESCRIPTION
Lors d'un import de blog, la class Import étend la class Backup. Et elle ferme la ressource avant le destructeur de la class Backup, d'où la levée d'exception.
Même avec le rapport d'erreur à E_ALL il est bon de ne pas lever une exception dans le destructeur. (le @ ne suffit pas dans ce cas)