### PR TITLE
Settings ns on the fly. Add  multiple behaviours.

### DIFF
--- a/inc/core/class.dc.core.php
+++ b/inc/core/class.dc.core.php
@@ -747,6 +747,29 @@ final class dcCore
     }
 
     /**
+     * Adds new behaviors to behaviors stack. Each row must 
+     * contains the behavior and a valid callable callback.
+     *
+     * @param      array    $behaviors  The behaviors
+     */
+    public function addBehaviors(array $behaviors): void
+    {
+        foreach($behaviors as $behavior => $func) {
+            $this->addBehavior($behavior, $func);
+        }
+    }
+
+    /**
+     * Adds behaviours (alias).
+     *
+     * @param      array    $behaviours  The behaviours
+     */
+    public function addBehaviours(array $behaviours): void
+    {
+        $this->addBehaviors($behaviours);
+    }
+
+    /**
      * Determines if behavior exists in behaviors stack.
      *
      * @param      string  $behavior  The behavior

--- a/inc/core/class.dc.settings.php
+++ b/inc/core/class.dc.settings.php
@@ -188,9 +188,9 @@ class dcSettings
      *
      * @return     dcNamespace
      */
-    public function get(string $namespace): ?dcNamespace
+    public function get(string $namespace): dcNamespace
     {
-        return ($this->namespaces[$namespace] ?? null);
+        return $this->addNamespace($namespace);
     }
 
     /**
@@ -200,7 +200,7 @@ class dcSettings
      *
      * @return     dcNamespace
      */
-    public function __get(string $namespace): ?dcNamespace
+    public function __get(string $namespace): dcNamespace
     {
         return $this->get($namespace);
     }


### PR DESCRIPTION
Je me suis encore fait avoir par github ou on ne peut pas séparer les commits en PR...
Donc :
- 1 commit pour pouvoir ajouter plusieurs behaviors en une fois, plus pratique que d'écrire 10 fois `dcCore::app()->addBehavior(...)`, rien de particulier ici.
- 1 commit pour créer les namespaces de settings à la volée, il peut y avoir des effets de bords si on test directement `dcCore::app()->blog->settings->system === null` mais je n'ai pas croisé dans les plugins survolés _(il y a la method `settings->exists()` pour ça)_ et ça rajoute un test à chaque lecture de setting. 

Le but de ces deux commit est de soulager de pas mal de lignes de code inutiles dans les plugins et thèmes
