### PR TITLE
Do not HTML-escape search query string twice

### DIFF
--- a/plugins/widgets/inc/default.widgets.php
+++ b/plugins/widgets/inc/default.widgets.php
@@ -177,7 +177,7 @@ class defaultWidgets
             return '';
         }
 
-        $value = isset(dcCore::app()->public->search) ? html::escapeHTML(dcCore::app()->public->search) : '';
+        $value = isset(dcCore::app()->public->search) ? dcCore::app()->public->search : '';
 
         return $widget->renderDiv(
             $widget->content_only,


### PR DESCRIPTION
It's already HTML-escaped when setting dcCore::app()->public->search.

The double HTML-escape results in wrongly displaying the query string in the search entry.