### PR TITLE
Adds _process_ class and autoloader for modules, addresses #232

### DIFF
--- a/admin/blog_theme.php
+++ b/admin/blog_theme.php
@@ -43,7 +43,10 @@ class adminBlogTheme
             // Display module configuration page
 
             // Get content before page headers
-            include dcCore::app()->admin->list->includeConfiguration();
+            $include = dcCore::app()->admin->list->includeConfiguration();
+            if ($include) {
+                include $include;
+            }
 
             // Gather content
             dcCore::app()->admin->list->getConfiguration();

--- a/admin/plugin.php
+++ b/admin/plugin.php
@@ -50,9 +50,8 @@ class adminPlugin
             ob_end_clean();
         // by file name
         } elseif (dcCore::app()->plugins->moduleExists($plugin)) {
-            $p_file = dcCore::app()->plugins->moduleRoot($plugin) . dcModules::MODULE_FILE_MANAGE;
+            $p_file = dcCore::app()->plugins->moduleRoot($plugin) . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_MANAGE;
             if (file_exists($p_file)) {
-                // Get plugin index.php content
                 ob_start();
                 include $p_file;
                 $res = (string) ob_get_contents();

--- a/admin/plugin.php
+++ b/admin/plugin.php
@@ -38,24 +38,32 @@ class adminPlugin
             $close_function = [dcPage::class, 'close'];
         }
 
-        if (dcCore::app()->plugins->moduleExists($plugin)) {
-            $p_file = dcCore::app()->plugins->moduleRoot($plugin) . '/index.php';
+        $res = '';
+        dcCore::app()->admin->setPageURL('plugin.php?p=' . $plugin);
+
+        // by class name
+        $class = dcCore::app()->plugins->loadNsClass($plugin, dcModules::MODULE_CLASS_MANAGE);
+        if (!empty($class)) {
+            ob_start();
+            $class::render();
+            $res = (string) ob_get_contents();
+            ob_end_clean();
+        // by file name
+        } elseif (dcCore::app()->plugins->moduleExists($plugin)) {
+            $p_file = dcCore::app()->plugins->moduleRoot($plugin) . dcModules::MODULE_FILE_MANAGE;
+            if (file_exists($p_file)) {
+                // Get plugin index.php content
+                ob_start();
+                include $p_file;
+                $res = (string) ob_get_contents();
+                ob_end_clean();
+            }
         }
 
-        if (file_exists($p_file)) {
-            // Loading plugin
-
-            dcCore::app()->admin->setPageURL('plugin.php?p=' . $plugin);
-
+        if (!empty($res)) {
             $p_title   = 'no content - plugin';
             $p_head    = '';
             $p_content = '<p>' . __('No content found on this plugin.') . '</p>';
-
-            // Get plugin index.php content
-            ob_start();
-            include $p_file;
-            $res = (string) ob_get_contents();
-            ob_end_clean();
 
             if (preg_match('|<head>(.*?)</head|ms', $res, $m)) {
                 // <head> present

--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -275,7 +275,10 @@ class adminPlugins
     public static function renderConfig()
     {
         // Get content before page headers
-        include dcCore::app()->admin->list->includeConfiguration();
+        $include = dcCore::app()->admin->list->includeConfiguration();
+        if ($include) {
+            include $include;
+        }
 
         // Gather content
         dcCore::app()->admin->list->getConfiguration();

--- a/inc/admin/lib.moduleslist.php
+++ b/inc/admin/lib.moduleslist.php
@@ -63,6 +63,12 @@ class adminModulesList
      */
     protected $config_module = [];
     /**
+     * Module class to configure
+     *
+     * @var        string
+     */
+    protected $config_class = '';
+    /**
      * Module path to configure
      *
      * @var        string
@@ -588,6 +594,7 @@ class adminModulesList
                 'current_version'   => 0,
                 'root'              => '',
                 'root_writable'     => false,
+                'namespace'         => '',
                 'permissions'       => null,
                 'parent'            => null,
                 'priority'          => dcModules::DEFAULT_PRIORITY,
@@ -919,8 +926,17 @@ class adminModulesList
                         '</ul></div>';
                 }
 
-                $config = !empty($module['root']) && file_exists(path::real($module['root'] . '/_config.php'));
-                $index  = !empty($module['root']) && file_exists(path::real($module['root'] . '/index.php'));
+                if (!empty($module['namespace']) && class_exists($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)) {
+                    $config = ($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)::init();
+                } else {
+                    $config = !empty($module['root']) && file_exists(path::real($module['root'] . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_CONFIG));
+                }
+
+                if (!empty($module['namespace']) && class_exists($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)) {
+                    $index = ($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)::init();
+                } else {
+                    $index = !empty($module['root']) && file_exists(path::real($module['root'] . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_MANAGE));
+                }
 
                 if ($config || $index || !empty($module['section']) || !empty($module['tags']) || !empty($module['settings']) || !empty($module['repository']) && DC_DEBUG && DC_ALLOW_REPOSITORIES) {
                     echo
@@ -993,8 +1009,20 @@ class adminModulesList
         $settings_urls = [];
 
         $module_root = dcCore::app()->plugins->moduleRoot($id);
-        $config      = !empty($module_root) && file_exists(path::real($module_root . '/_config.php'));
-        $index       = !empty($module_root) && file_exists(path::real($module_root . '/index.php'));
+        $module_ns = dcCore::app()->plugins->moduleInfo($id, 'namespace');
+
+        if (!empty($module_ns) && class_exists($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)) {
+            $config = ($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)::init();
+        } else {
+            $config = !empty($module_root) && file_exists(path::real($module_root . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_CONFIG));
+        }
+
+        if (!empty($module_ns) && class_exists($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)) {
+            $index = ($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)::init();
+        } else {
+            $index = !empty($module_root) && file_exists(path::real($module_root . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_MANAGE));
+        }
+
         $settings    = dcCore::app()->plugins->moduleInfo($id, 'settings');
         if ($self) {
             if (isset($settings['self']) && $settings['self'] === false) {
@@ -1576,9 +1604,11 @@ class adminModulesList
 
         $module = $this->modules->getModules($id);
         $module = self::sanitizeModule($id, $module);
-        $file   = path::real($module['root'] . '/_config.php');
+        $class = $module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG;
+        $class = empty($module['namespace']) || !class_exists($class) ? '' : $class;
+        $file   = path::real($module['root'] . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_CONFIG);
 
-        if (!file_exists($file)) {
+        if (empty($class) && !file_exists($file)) {
             dcCore::app()->error->add(__('This plugin has no configuration file.'));
 
             return false;
@@ -1593,6 +1623,7 @@ class adminModulesList
         }
 
         $this->config_module  = $module;
+        $this->config_class   = $class;
         $this->config_file    = $file;
         $this->config_content = '';
 
@@ -1612,12 +1643,18 @@ class adminModulesList
      */
     public function includeConfiguration()
     {
-        if (!$this->config_file) {
+        if (empty($this->config_class) && !$this->config_file) {
             return;
         }
         $this->setRedir($this->getURL() . '#plugins');
 
         ob_start();
+
+        if (!empty($this->config_class) && $this->config_class::init() && $this->config_class::process()) {
+            $this->config_class::render();
+
+            return null;
+        }
 
         return $this->config_file;
     }
@@ -1631,7 +1668,7 @@ class adminModulesList
      */
     public function getConfiguration(): bool
     {
-        if ($this->config_file) {
+        if (!empty($this->config_class) || !empty($this->config_file)) {
             $this->config_content = ob_get_contents();
         }
 
@@ -1649,7 +1686,7 @@ class adminModulesList
      */
     public function displayConfiguration(): adminModulesList
     {
-        if ($this->config_file) {
+        if (!empty($this->config_class) || !empty($this->config_file)) {
             if (!$this->config_module['standalone_config']) {
                 echo
                 '<form id="module_config" action="' . $this->getURL('conf=1') . '" method="post" enctype="multipart/form-data">' .

--- a/inc/admin/lib.moduleslist.php
+++ b/inc/admin/lib.moduleslist.php
@@ -926,14 +926,18 @@ class adminModulesList
                         '</ul></div>';
                 }
 
+                // by class name
                 if (!empty($module['namespace']) && class_exists($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)) {
                     $config = ($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)::init();
+                // by file name
                 } else {
                     $config = !empty($module['root']) && file_exists(path::real($module['root'] . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_CONFIG));
                 }
 
+                // by class name
                 if (!empty($module['namespace']) && class_exists($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)) {
                     $index = ($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)::init();
+                // by file name
                 } else {
                     $index = !empty($module['root']) && file_exists(path::real($module['root'] . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_MANAGE));
                 }
@@ -1011,14 +1015,18 @@ class adminModulesList
         $module_root = dcCore::app()->plugins->moduleRoot($id);
         $module_ns = dcCore::app()->plugins->moduleInfo($id, 'namespace');
 
+        // by class name
         if (!empty($module_ns) && class_exists($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)) {
             $config = ($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)::init();
+        // by file name
         } else {
             $config = !empty($module_root) && file_exists(path::real($module_root . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_CONFIG));
         }
 
+        // by class name
         if (!empty($module_ns) && class_exists($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)) {
             $index = ($module_ns . Autoloader::NS_SEP . dcModules::MODULE_CLASS_MANAGE)::init();
+        // by file name
         } else {
             $index = !empty($module_root) && file_exists(path::real($module_root . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_MANAGE));
         }
@@ -1911,7 +1919,15 @@ class adminThemesList extends adminModulesList
 
                 $line .= '<div class="current-actions">';
 
-                if (file_exists(path::real(dcCore::app()->blog->themes_path . '/' . $id) . '/_config.php')) {
+                // by class name
+                if (!empty($module['namespace']) && class_exists($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)) {
+                    $config = ($module['namespace'] . Autoloader::NS_SEP . dcModules::MODULE_CLASS_CONFIG)::init();
+                // by file name
+                } else {
+                    $config = file_exists(path::real(dcCore::app()->blog->themes_path . '/' . $id) . DIRECTORY_SEPARATOR . dcModules::MODULE_FILE_CONFIG);
+                }
+
+                if ($config) {
                     $line .= '<p><a href="' . $this->getURL('module=' . $id . '&amp;conf=1', false) . '" class="button submit">' . __('Configure theme') . '</a></p>';
                 }
 

--- a/inc/core/class.dc.modules.php
+++ b/inc/core/class.dc.modules.php
@@ -50,7 +50,7 @@ class dcModules
      *
      * @var        string
      */
-    public const MODULE_CLASS_DIR     = 'inc';
+    public const MODULE_CLASS_DIR     = 'src';
     public const MODULE_CLASS_PREPEND = 'Prepend';
     public const MODULE_CLASS_INSTALL = 'Install';
     public const MODULE_CLASS_ADMIN   = 'Admin';

--- a/inc/core/class.dc.ns.process.php
+++ b/inc/core/class.dc.ns.process.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @brief Modules handler
+ *
+ * Provides an object to handle modules class (themes or plugins).
+ * (Before as modules file in dcModules::loadNsFile)
+ *
+ * @package Dotclear
+ * @subpackage Core
+ *
+ * @copyright Olivier Meunier & Association Dotclear
+ * @copyright GPL-2.0-only
+ */
+abstract class dcNsProcess
+{
+    /**
+     * Class is initialized and ok to be used.
+     *
+     * @var bool
+     */
+    protected static $init = false;
+
+    /**
+     * Initilise class.
+     *
+     * @return bool  true if class can be used
+     */
+    abstract public static function init(): bool;
+
+    /**
+     * Performs action and/or prepares render.
+     * 
+     * It must return:
+     * - true to enable render
+     * - false to disable
+     *
+     * @return bool  true if process succeed
+     */
+    public static function process(): bool
+    {
+        return self::$init;
+    }
+
+    /**
+     * Render process.
+     * 
+     * This method is used to render something.
+     * (echo something to std ouput, etc...)
+     */
+    public static function render(): void
+    {
+        /**
+        if (!self::$init) {
+            return;
+        }
+
+        echo 'well done!';
+        */
+    }
+}

--- a/inc/helper/_common.php
+++ b/inc/helper/_common.php
@@ -98,6 +98,7 @@ class Clearbricks
 
         $this->autoloader->add([
             // Common helpers
+            'Autoloader'       => __DIR__ . '/common/Autoloader.php',
             'crypt'            => __DIR__ . '/common/lib.crypt.php',
             'dt'               => __DIR__ . '/common/lib.date.php',
             'files'            => __DIR__ . '/common/lib.files.php',

--- a/inc/helper/common/Autoloader.php
+++ b/inc/helper/common/Autoloader.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * @package Dotclear
+ *
+ * @copyright Olivier Meunier & Association Dotclear
+ * @copyright GPL-2.0-only
+ */
+declare(strict_types=1);
+
+/**
+ * Helper to autoload class using php namespace.
+ *
+ * Based on PSR-4 Autoloader
+ * https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
+ *
+ * A root prefix and base directory can be added to all ns
+ * to work with non full standardized project.
+ *
+ * @ingroup  Helper Autoload Stack
+ */
+class Autoloader
+{
+    /** Directory separator */
+    public const DIR_SEP = DIRECTORY_SEPARATOR;
+
+    /** Namespace separator */
+    public const NS_SEP = '\\';
+
+    /**
+     * @var string $root_prefix
+     *             Root namespace prepend to added ns
+     */
+    private $root_prefix = '';
+
+    /**
+     * @var string $root_base_dir
+     *             Root directory prepend to added ns
+     */
+    private $root_base_dir = '';
+
+    /**
+     * @var array<string,array> $prefixes
+     *                          Array of registered namespace [prefix=[base dir]]
+     */
+    private $prefixes = [];
+
+    /**
+     * @var int $loads_count
+     *          Keep track of loads count
+     */
+    private $loads_count = 0;
+
+    /**
+     * @var int $request_count
+     *          Keep track of request count
+     */
+    private $request_count = 0;
+
+    /**
+     * Register loader with SPL autoloader stack.
+     *
+     * @param string $root_prefix   Common ns prefix
+     * @param string $root_base_dir Common dir prefix
+     * @param bool   $prepend       Add loader on top of stack
+     */
+    public function __construct(string $root_prefix = '', string $root_base_dir = '', bool $prepend = false)
+    {
+        if (!empty($root_prefix)) {
+            $this->root_prefix = $this->normalizePrefix($root_prefix);
+        }
+        if (!empty($root_base_dir)) {
+            $this->root_base_dir = $this->normalizeBaseDir($root_base_dir);
+        }
+
+        // @phpstan-ignore-next-line (Failed to see array as callable but works great)
+        spl_autoload_register([$this, 'loadClass'], true, $prepend);
+    }
+
+    /**
+     * Get root prefix.
+     *
+     * @return string Root prefix
+     */
+    public function getRootPrefix(): string
+    {
+        return $this->root_prefix;
+    }
+
+    /**
+     * Get root base directory.
+     *
+     * @return string Root base directory
+     */
+    public function getRootBaseDir(): string
+    {
+        return $this->root_base_dir;
+    }
+
+    /**
+     * Normalize namespace prefix.
+     *
+     * @param string $prefix Ns prefix
+     *
+     * @return string Prefix with only right namesapce separator
+     */
+    public function normalizePrefix(string $prefix): string
+    {
+        return ucfirst(trim($prefix, self::NS_SEP)) . self::NS_SEP;
+    }
+
+    /**
+     * Normalize base directory.
+     *
+     * @param string $base_dir Dir prefix
+     *
+     * @return string Base dir with right directory separator
+     */
+    public function normalizeBaseDir(string $base_dir): string
+    {
+        return rtrim($base_dir, self::DIR_SEP) . self::DIR_SEP;
+    }
+
+    /**
+     * Clean up a string into namespace part.
+     *
+     * @param string $str string to clean
+     *
+     * @return null|string Cleaned string or null if empty
+     */
+    public function qualifyNamespace(string $str): ?string
+    {
+        $str = preg_replace(
+            [
+                '/[^a-zA-Z0-9_' . preg_quote(self::NS_SEP) . ']/',
+                '/[' . preg_quote(self::NS_SEP) . ']{2,}/',
+            ],
+            [
+                '',
+                self::NS_SEP,
+            ],
+            $str
+        );
+
+        return empty($str) ? null : $this->normalizePrefix($str);
+    }
+
+    /**
+     * Adds a base directory for a namespace prefix.
+     *
+     * @param string $prefix   the namespace prefix
+     * @param string $base_dir a base directory for class files in the namespace
+     * @param bool   $prepend  if true, prepend the base directory to the stack
+     *                         instead of appending it; this causes it to be searched first rather
+     *                         than last
+     */
+    public function addNamespace(string $prefix, string $base_dir, bool $prepend = false): void
+    {
+        $prefix   = $this->root_prefix . $this->normalizePrefix($prefix);
+        $base_dir = $this->root_base_dir . $this->normalizeBaseDir($base_dir);
+
+        if (false === isset($this->prefixes[$prefix])) {
+            $this->prefixes[$prefix] = [];
+        }
+
+        if ($prepend) {
+            array_unshift($this->prefixes[$prefix], $base_dir);
+        } else {
+            array_push($this->prefixes[$prefix], $base_dir);
+        }
+    }
+
+    /**
+     * Get list of registered namespace.
+     *
+     * @return array List of namesapce prefix / base dir
+     */
+    public function getNamespaces(): array
+    {
+        return $this->prefixes;
+    }
+
+    /**
+     * Loads the class file for a given class name.
+     *
+     * @param string $class the fully-qualified class name
+     *
+     * @return null|string the mapped file name on success, or null on failure
+     */
+    public function loadClass(string $class): ?string
+    {
+        ++$this->request_count;
+        $prefix = $class;
+
+        while (false !== $pos = strrpos($prefix, self::NS_SEP)) {
+            $prefix         = substr($class, 0, $pos + 1);
+            $relative_class = substr($class, $pos    + 1);
+
+            $mapped_file = $this->loadMappedFile($prefix, $relative_class);
+            if ($mapped_file) {
+                return $mapped_file;
+            }
+
+            $prefix = rtrim($prefix, self::NS_SEP);
+        }
+
+        return null;
+    }
+
+    /**
+     * Load the mapped file for a namespace prefix and relative class.
+     *
+     * @param string $prefix         the namespace prefix
+     * @param string $relative_class the relative class name
+     *
+     * @return null|string null if no mapped file can be loaded, or the
+     *                     name of the mapped file that was loaded
+     */
+    private function loadMappedFile(string $prefix, string $relative_class): ?string
+    {
+        if (false === isset($this->prefixes[$prefix])) {
+            return null;
+        }
+
+        foreach ($this->prefixes[$prefix] as $base_dir) {
+            $file = $base_dir
+                  . str_replace(self::NS_SEP, self::DIR_SEP, $relative_class)
+                  . '.php';
+
+            if ($this->requireFile($file)) {
+                return $file;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * If a file exists, require it from the file system.
+     *
+     * @param string $file the file to require
+     *
+     * @return bool true if the file exists, false if not
+     */
+    private function requireFile(string $file): bool
+    {
+        if (is_file($file)) {
+            ++$this->loads_count;
+
+            require $file;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get number of loads on this autoloader.
+     *
+     * @return int Number of loads
+     */
+    public function getLoadsCount(): int
+    {
+        return $this->loads_count;
+    }
+
+    /**
+     * Get number of requests on this autoloader.
+     *
+     * @return int Number of requests
+     */
+    public function getRequestsCount(): int
+    {
+        return $this->request_count;
+    }
+}

--- a/inc/prepend.php
+++ b/inc/prepend.php
@@ -40,6 +40,7 @@ Clearbricks::lib()->autoload([
     'dcMeta'                   => implode(DIRECTORY_SEPARATOR, [__DIR__, 'core', 'class.dc.meta.php']),
     'dcMedia'                  => implode(DIRECTORY_SEPARATOR, [__DIR__, 'core', 'class.dc.media.php']),
     'dcPostMedia'              => implode(DIRECTORY_SEPARATOR, [__DIR__, 'core', 'class.dc.postmedia.php']),
+    'dcNsProcess'              => implode(DIRECTORY_SEPARATOR, [__DIR__, 'core', 'class.dc.ns.process.php']),
     'dcModules'                => implode(DIRECTORY_SEPARATOR, [__DIR__, 'core', 'class.dc.modules.php']),
     'dcPlugins'                => implode(DIRECTORY_SEPARATOR, [__DIR__, 'core', 'class.dc.plugins.php']),
     'dcThemes'                 => implode(DIRECTORY_SEPARATOR, [__DIR__, 'core', 'class.dc.themes.php']),


### PR DESCRIPTION
Le but est de faciliter l'écriture des plugins et d'uniformiser les appelles de méthodes communément utilisés aujourd'hui.

- Ajoute un autoloader un peu particulier, qui pourrait bien rendre service dans le futur.
- Double tous les appelles aux fichiers de modules par des appelles aux classes des modules.
- Automatise les mécanisme d'enregistrement de class et d'appelle à leurs methodes "standards"

Voir les exemples des branches NsClass des plugins pacKman et improve:
- https://github.com/JcDenis/pacKman/tree/NsClass
- https://github.com/JcDenis/improve/tree/NsClass

On ne reprend pas l'autoloader existant de clearbricks, car celui-ci s'utilise différemment, plus générique et se rapproche des outils modernes. Les deux cohabitent sans problème.
Les deux formes d'écriture des plugins/themes restent valable (jusqu'à qu'on décide du contraire!).
Pour la démonstration, le dossier _inc_ des plugins est définie comme source des class (constante dans dcModules), mais il serait opportun d'utiliser un dossier _src_ afin de débuter en étant possiblment compatible avec de futur outils externes (Composer etc...)

Par la suite cette méthode d'appelle pourra être étendu à pas mal de class de dotclear.