### PR TITLE
fix redeclared class on update

### DIFF
--- a/inc/core/class.dc.modules.php
+++ b/inc/core/class.dc.modules.php
@@ -125,6 +125,13 @@ class dcModules
     protected $modules_names = [];
 
     /**
+     * Stack of modules files to track (on update)
+     *
+     * @var        array
+     */
+    protected $modules_files = ['init' => []];
+
+    /**
      * Stack of all modules
      *
      * @var        array
@@ -399,7 +406,8 @@ class dcModules
             $root = rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
             foreach ($stack as $entry) {
                 $full_entry = $root . $entry;
-                if (file_exists($full_entry . DIRECTORY_SEPARATOR . self::MODULE_FILE_INIT)) {
+                if (!in_array($entry, $this->modules_files['init']) && file_exists($full_entry . DIRECTORY_SEPARATOR . self::MODULE_FILE_INIT)) {
+                    $this->modules_files['init'][] = $entry;
                     ob_start();
                     require $full_entry . DIRECTORY_SEPARATOR . self::MODULE_FILE_INIT;
                     ob_end_clean();
@@ -534,7 +542,8 @@ class dcModules
         if (file_exists($dir . DIRECTORY_SEPARATOR . self::MODULE_FILE_DEFINE)) {
             $this->id = $id;
             ob_start();
-            if (file_exists($dir . DIRECTORY_SEPARATOR . self::MODULE_FILE_INIT)) {
+            if (!in_array($id, $this->modules_files['init']) && file_exists($dir . DIRECTORY_SEPARATOR . self::MODULE_FILE_INIT)) {
+                $this->modules_files['init'][] = $id;
                 require $dir . DIRECTORY_SEPARATOR . self::MODULE_FILE_INIT;
             }
             require $dir . DIRECTORY_SEPARATOR . self::MODULE_FILE_DEFINE;


### PR DESCRIPTION
Demi correction qui empêche de redéclarer une classe déjà connu lors de la mise à jour d'un module. (typiquement présente dans le fichier _init.php) Si ce cas arrive, la classe contenu dans le fichier zip n'est pas chargé, ce qui peut causer problème si elle contient une modification importante par rapport au module déjà installé.