### PR TITLE
Remove pragma for correct caching behaviour

### DIFF
--- a/inc/helper/common/lib.http.php
+++ b/inc/helper/common/lib.http.php
@@ -324,7 +324,6 @@ class http
         # Common headers list
         $headers[] = 'Last-Modified: ' . gmdate('D, d M Y H:i:s', $timestamp) . ' GMT';
         $headers[] = 'Cache-Control: must-revalidate, max-age=' . abs((int) self::$cache_max_age);
-        $headers[] = 'Pragma:';
 
         if ($since >= $timestamp) {
             self::head(304, 'Not Modified');


### PR DESCRIPTION
This header has been long deprecated. It prevents caching when the website is behind cloudflare. We are already specifying Cache-Control hence this is not required.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma