### PR TITLE
Correction de l’affichage de la liste des billets sur mobile

### DIFF
--- a/admin/js/_posts_list.js
+++ b/admin/js/_posts_list.js
@@ -59,5 +59,5 @@ dotclear.ready(() => {
   dotclear.enableShiftClick('#form-entries td input[type=checkbox]');
   dotclear.condSubmit('#form-entries td input[type=checkbox]', '#form-entries #do-action');
   dotclear.postsActionsHelper();
-  dotclear.responsiveCellHeaders(document.querySelector('#form-entries table'), '#form-entries table', 1);
+  dotclear.responsiveCellHeaders(document.querySelector('#form-entries table'), '#form-entries table', 1, true);
 });


### PR DESCRIPTION
Bonjour,

En consultant l’administration de mon blog depuis mon téléphone, j’ai remarqué que le premier billet de la page Billets était systématiquement masqué.

Il me semble qu’il manque juste un `true` à la fonction `responsiveCellHeaders()` dans le fichier `_posts_list.js`, ligne 62.